### PR TITLE
Update BlogMLFormatter.cs

### DIFF
--- a/MiniBlogFormatter/Formatters/BlogMLFormatter.cs
+++ b/MiniBlogFormatter/Formatters/BlogMLFormatter.cs
@@ -48,7 +48,17 @@ namespace MiniBlogFormatter
             XElement author = postData.Descendants(ns + "author").FirstOrDefault();
 
             if (author != null)
-                post.Author = authors[author.Attribute("ref").Value];
+            {
+                var thisArthor = author.Attribute("ref").Value;
+                foreach(var thisKey in authors.Keys)
+                {
+                    // Fixes issue when author name has different cases from the Key value of Authors
+                    if(thisArthor.Equals(thisKey, StringComparison.CurrentCultureIgnoreCase))
+                    {
+                        post.Author = authors[thisKey];
+                    }
+                }
+            }
 
             foreach (XElement commentData in postData.Descendants(ns + "comment"))
             {


### PR DESCRIPTION
While processing a BlogEngine.Net 2.0.0.36 generated BlogML file, some of the author names had different casing.  This change correctly finds the author without throwing an exception.
