### PR TITLE
support image/file urls without leading slash in blogengine formatter

### DIFF
--- a/MiniBlogFormatter/Formatters/BlogEngineFormatter.cs
+++ b/MiniBlogFormatter/Formatters/BlogEngineFormatter.cs
@@ -6,7 +6,7 @@ namespace MiniBlogFormatter
 {
     public class BlogEngineFormatter
     {
-        private Regex rxFiles = new Regex("(href|src)=\"(([^\"]+)?/(file|image)\\.axd\\?(file|picture)=([^\"]+))\"", RegexOptions.IgnoreCase);
+        private Regex rxFiles = new Regex("(href|src)=\"(([^\"]+)?(file|image)\\.axd\\?(file|picture)=([^\"]+))\"", RegexOptions.IgnoreCase);
         private Regex rxAggBug = new Regex("<img (.*) src=(.*(aggbug.ashx).*) />", RegexOptions.IgnoreCase);
 
         public void Format(string fileName, string targetFolderPath, string categoriesFileName)


### PR DESCRIPTION
When migrating my blog to MiniBlog I noticed that relative image urls that didn't have any path before the handler or at least a leading slash were not updated by the formatter. 